### PR TITLE
Fix: bump rate limit

### DIFF
--- a/main.go
+++ b/main.go
@@ -454,7 +454,7 @@ func NewOAuthProxy() (*OAuthProxy, error) {
 	// Initialize rate limiter
 	rateLimiter := NewRateLimiter(
 		time.Duration(15)*time.Minute,
-		100,
+		5000,
 	)
 
 	// Initialize provider manager


### PR DESCRIPTION
During one of the meetup when a lot of people trying to sign up and use our google sheet mcp server, it reached the rate limit. The default rate limit is too low and we should bump it.