### PR TITLE
refactor: stop rewriting paths in proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ You can customize the scopes based on your needs. Common additional scopes inclu
          OAUTH_CLIENT_ID: "your-oauth-client-id"
          OAUTH_CLIENT_SECRET: "your-oauth-client-secret"
          OAUTH_AUTHORIZE_URL: "https://your-oauth-provider.com/oauth/authorize"
-         MCP_SERVER_URL: "http://localhost:3000/mcp"
+         MCP_SERVER_URL: "http://localhost:3000"
          ENCRYPTION_KEY: "your-base64-encoded-32-byte-key"
        ports:
          - "8080:8080"
@@ -295,7 +295,7 @@ You can customize the scopes based on your needs. Common additional scopes inclu
          OAUTH_CLIENT_ID: "your-oauth-client-id"
          OAUTH_CLIENT_SECRET: "your-oauth-client-secret"
          OAUTH_AUTHORIZE_URL: "https://your-oauth-provider.com/oauth/authorize"
-         MCP_SERVER_URL: "http://localhost:3000/mcp"
+         MCP_SERVER_URL: "http://localhost:3000"
        volumes:
          - ./data:/app/data # Persist SQLite database
        ports:
@@ -342,7 +342,7 @@ You can customize the scopes based on your needs. Common additional scopes inclu
 
 ### MCP Proxy
 
-- `ANY /mcp/*` - Proxies requests to MCP server with user context headers
+- `ANY /*` - Proxies any request not mentioned above to MCP server with user context headers
 
 ## OAuth Flow
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   #     OAUTH_CLIENT_ID: "your-oauth-client-id"
   #     OAUTH_CLIENT_SECRET: "your-oauth-client-secret"
   #     OAUTH_AUTHORIZE_URL: "https://your-oauth-provider.com/oauth/authorize"
-  #     MCP_SERVER_URL: "http://localhost:3000/mcp"
+  #     MCP_SERVER_URL: "http://localhost:3000"
   #   ports:
   #     - "8080:8080"
   #   depends_on:

--- a/main.go
+++ b/main.go
@@ -9,7 +9,10 @@ import (
 
 func main() {
 	// Load configuration from environment variables
-	config := proxy.LoadConfigFromEnv()
+	config, err := proxy.LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
 
 	proxy, err := proxy.NewOAuthProxy(config)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -61,7 +62,10 @@ func TestIntegrationFlow(t *testing.T) {
 	}()
 
 	// Create OAuth proxy
-	config := proxy.LoadConfigFromEnv()
+	config, err := proxy.LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
 	oauthProxy, err := proxy.NewOAuthProxy(config)
 	if err != nil {
 		t.Skipf("Skipping test due to database connection error: %v", err)
@@ -99,7 +103,7 @@ func TestIntegrationFlow(t *testing.T) {
 	// Test protected resource metadata
 	t.Run("ProtectedResourceMetadata", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource/mcp", nil)
+		req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
 		handler.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
@@ -165,7 +169,10 @@ func TestOAuthProxyCreation(t *testing.T) {
 	}()
 
 	// Create OAuth proxy
-	config := proxy.LoadConfigFromEnv()
+	config, err := proxy.LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
 	oauthProxy, err := proxy.NewOAuthProxy(config)
 	require.NoError(t, err, "Should be able to create OAuth proxy with valid environment")
 	require.NotNil(t, oauthProxy, "OAuth proxy should not be nil")
@@ -215,7 +222,10 @@ func TestOAuthProxyStart(t *testing.T) {
 	}()
 
 	// Create OAuth proxy
-	config := proxy.LoadConfigFromEnv()
+	config, err := proxy.LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
 	oauthProxy, err := proxy.NewOAuthProxy(config)
 	require.NoError(t, err)
 	defer func() {

--- a/pkg/oauth/validate/validatetoken.go
+++ b/pkg/oauth/validate/validatetoken.go
@@ -28,7 +28,7 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
 			// Return 401 with proper WWW-Authenticate header
-			resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource/mcp", handlerutils.GetBaseURL(r))
+			resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource", handlerutils.GetBaseURL(r))
 			wwwAuthValue := fmt.Sprintf(`Bearer error="invalid_token", error_description="Missing Authorization header", resource_metadata="%s"`, resourceMetadataUrl)
 			w.Header().Set("WWW-Authenticate", wwwAuthValue)
 			handlerutils.JSON(w, http.StatusUnauthorized, map[string]string{
@@ -41,7 +41,7 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 		// Parse Authorization header
 		parts := strings.SplitN(authHeader, " ", 2)
 		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" || parts[1] == "" {
-			resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource/mcp", handlerutils.GetBaseURL(r))
+			resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource", handlerutils.GetBaseURL(r))
 			wwwAuthValue := fmt.Sprintf(`Bearer error="invalid_token", error_description="Invalid Authorization header format, expected 'Bearer TOKEN'", resource_metadata="%s"`, resourceMetadataUrl)
 			w.Header().Set("WWW-Authenticate", wwwAuthValue)
 			handlerutils.JSON(w, http.StatusUnauthorized, map[string]string{
@@ -55,7 +55,7 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 
 		tokenInfo, err := p.tokenManager.GetTokenInfo(token)
 		if err != nil {
-			resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource/mcp", handlerutils.GetBaseURL(r))
+			resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource", handlerutils.GetBaseURL(r))
 			wwwAuthValue := fmt.Sprintf(`Bearer error="invalid_token", error_description="Invalid or expired token", resource_metadata="%s"`, resourceMetadataUrl)
 			w.Header().Set("WWW-Authenticate", wwwAuthValue)
 			handlerutils.JSON(w, http.StatusUnauthorized, map[string]string{
@@ -69,7 +69,7 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 		if tokenInfo.Props != nil {
 			decryptedProps, err := encryption.DecryptPropsIfNeeded(p.encryptionKey, tokenInfo.Props)
 			if err != nil {
-				resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource/mcp", handlerutils.GetBaseURL(r))
+				resourceMetadataUrl := fmt.Sprintf("%s/.well-known/oauth-protected-resource", handlerutils.GetBaseURL(r))
 				wwwAuthValue := fmt.Sprintf(`Bearer error="invalid_token", error_description="Failed to decrypt token data", resource_metadata="%s"`, resourceMetadataUrl)
 				w.Header().Set("WWW-Authenticate", wwwAuthValue)
 				handlerutils.JSON(w, http.StatusUnauthorized, map[string]string{


### PR DESCRIPTION
This change also properly handles redirects from the downstream MCP server and rewrites them to point to the proxy.