### PR TITLE
feat: support API key authentication for Obot

### DIFF
--- a/pkg/oauth/validate/validatetoken.go
+++ b/pkg/oauth/validate/validatetoken.go
@@ -105,30 +105,45 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 			fromCookie = false
 		}
 
-		tokenInfo, err := p.tokenManager.GetTokenInfo(token)
-		if err != nil {
-			p.sendUnauthorizedResponse(w, r, "Invalid or expired token")
-			return
-		}
+		// Check if this is an API key - use context-aware validation
+		var tokenInfo *tokens.TokenInfo
+		var err error
+		if tokens.IsAPIKey(token) {
+			// API keys are validated against the webhook on every request (no caching)
+			// Pass empty server IDs for now - basic authentication without scoped authorization
+			tokenInfo, err = p.tokenManager.GetTokenInfoWithContext(r.Context(), token, "", "")
+			if err != nil {
+				p.sendUnauthorizedResponse(w, r, fmt.Sprintf("Invalid or expired API key: %v", err))
+				return
+			}
+		} else {
+			// Existing JWT/simple token validation
+			tokenInfo, err = p.tokenManager.GetTokenInfo(token)
+			if err != nil {
+				p.sendUnauthorizedResponse(w, r, "Invalid or expired token")
+				return
+			}
 
-		// Check if token is within 15 minutes of expiring and attempt refresh if from cookie
-		if fromCookie && time.Until(tokenInfo.ExpiresAt) < 15*time.Minute {
-			newToken, refreshErr := p.refreshAccessToken(w, r)
-			if refreshErr != nil {
-				// If token is already expired, refresh is required
-				if time.Now().After(tokenInfo.ExpiresAt) {
-					p.sendUnauthorizedResponse(w, r, "Token expired and refresh failed")
-					return
-				}
-				// Token not yet expired, log warning and continue with current token
-				fmt.Printf("Token refresh failed but token still valid, continuing: %v\n", refreshErr)
-			} else {
-				// Refresh succeeded, use new token and get updated token info
-				token = newToken
-				tokenInfo, err = p.tokenManager.GetTokenInfo(token)
-				if err != nil {
-					p.sendUnauthorizedResponse(w, r, "Failed to validate refreshed token")
-					return
+			// Check if token is within 15 minutes of expiring and attempt refresh if from cookie
+			// Note: API keys don't use cookies or refresh tokens
+			if fromCookie && time.Until(tokenInfo.ExpiresAt) < 15*time.Minute {
+				newToken, refreshErr := p.refreshAccessToken(w, r)
+				if refreshErr != nil {
+					// If token is already expired, refresh is required
+					if time.Now().After(tokenInfo.ExpiresAt) {
+						p.sendUnauthorizedResponse(w, r, "Token expired and refresh failed")
+						return
+					}
+					// Token not yet expired, log warning and continue with current token
+					fmt.Printf("Token refresh failed but token still valid, continuing: %v\n", refreshErr)
+				} else {
+					// Refresh succeeded, use new token and get updated token info
+					token = newToken
+					tokenInfo, err = p.tokenManager.GetTokenInfo(token)
+					if err != nil {
+						p.sendUnauthorizedResponse(w, r, "Failed to validate refreshed token")
+						return
+					}
 				}
 			}
 		}

--- a/pkg/oauth/validate/validatetoken.go
+++ b/pkg/oauth/validate/validatetoken.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -106,12 +107,13 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 		}
 
 		// Check if this is an API key - use context-aware validation
-		var tokenInfo *tokens.TokenInfo
-		var err error
+		var (
+			tokenInfo *tokens.TokenInfo
+			err       error
+		)
 		if tokens.IsAPIKey(token) {
 			// API keys are validated against the webhook on every request (no caching)
-			// Pass empty server IDs for now - basic authentication without scoped authorization
-			tokenInfo, err = p.tokenManager.GetTokenInfoWithContext(r.Context(), token, "", "")
+			tokenInfo, err = p.tokenManager.GetTokenInfoWithContext(r.Context(), token, os.Getenv("MCP_SERVER_ID"))
 			if err != nil {
 				p.sendUnauthorizedResponse(w, r, fmt.Sprintf("Invalid or expired API key: %v", err))
 				return

--- a/pkg/oauth/validate/validatetoken.go
+++ b/pkg/oauth/validate/validatetoken.go
@@ -115,9 +115,7 @@ func (p *TokenValidator) WithTokenValidation(next http.HandlerFunc) http.Handler
 		}
 
 		// Check if token is within 15 minutes of expiring and attempt refresh if from cookie
-		// Note: API keys don't use cookies or refresh tokens
-		isAPIKey := tokenInfo.Props != nil && tokenInfo.Props["api_key"] == true
-		if !isAPIKey && fromCookie && time.Until(tokenInfo.ExpiresAt) < 15*time.Minute {
+		if fromCookie && time.Until(tokenInfo.ExpiresAt) < 15*time.Minute {
 			newToken, refreshErr := p.refreshAccessToken(w, r)
 			if refreshErr != nil {
 				// If token is already expired, refresh is required

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -110,7 +110,7 @@ func NewOAuthProxy(config *types.Config) (*OAuthProxy, error) {
 	}
 
 	// Initialize token manager with JWKS and API key auth support
-	tokenManager, err := tokens.NewTokenManagerWithJWKSURLAndAPIKeyAuth(db, config.OAuthJWKSURL, config.APIKeyAuthURL)
+	tokenManager, err := tokens.NewTokenManagerWithJWKSURLAndAPIKeyAuth(db, config.OAuthJWKSURL, config.APIKeyAuthWebhookURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize token manager: %w", err)
 	}
@@ -210,7 +210,7 @@ func (p *OAuthProxy) SetupRoutes(mux *http.ServeMux, next http.Handler) {
 	tokenHandler := token.NewHandler(p.db)
 	callbackHandler := callback.NewHandler(p.db, provider, p.encryptionKey, p.GetOAuthClientID(), p.GetOAuthClientSecret(), p.config.RoutePrefix, p.config.CookieNamePrefix)
 	revokeHandler := revoke.NewHandler(p.db)
-	tokenValidator := validate.NewTokenValidator(p.tokenManager, p.encryptionKey, p.db, provider, p.config.RoutePrefix, p.GetOAuthClientID(), p.GetOAuthClientSecret(), p.config.CookieNamePrefix, p.metadata.ScopesSupported, p.config.MCPPaths)
+	tokenValidator := validate.NewTokenValidator(p.tokenManager, p.encryptionKey, p.db, provider, p.config.RoutePrefix, p.GetOAuthClientID(), p.GetOAuthClientSecret(), p.config.CookieNamePrefix, p.config.MCPServerID, p.metadata.ScopesSupported, p.config.MCPPaths)
 	successHandler := success.NewHandler()
 
 	// Get route prefix from config

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -109,8 +109,8 @@ func NewOAuthProxy(config *types.Config) (*OAuthProxy, error) {
 		provider = "generic"
 	}
 
-	// Initialize token manager
-	tokenManager, err := tokens.NewTokenManagerWithJWKSURL(db, config.OAuthJWKSURL)
+	// Initialize token manager with JWKS and API key auth support
+	tokenManager, err := tokens.NewTokenManagerWithJWKSURLAndAPIKeyAuth(db, config.OAuthJWKSURL, config.APIKeyAuthURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize token manager: %w", err)
 	}

--- a/pkg/tokens/apikey.go
+++ b/pkg/tokens/apikey.go
@@ -6,21 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/obot-platform/mcp-oauth-proxy/pkg/types"
 )
-
-const (
-	// APIKeyPrefix is the prefix that identifies Obot API keys.
-	APIKeyPrefix = "ok1-"
-)
-
-// IsAPIKey checks if the token is an Obot API key (starts with "ok1-").
-func IsAPIKey(token string) bool {
-	return strings.HasPrefix(token, APIKeyPrefix)
-}
 
 // APIKeyValidator validates API keys by calling the authentication webhook.
 type APIKeyValidator struct {
@@ -83,12 +72,12 @@ func (v *APIKeyValidator) ValidateAPIKey(ctx context.Context, apiKey, mcpID stri
 	}
 
 	userInfo, _ := json.Marshal(map[string]any{
-		"sub":      fmt.Sprintf("%d", authResp.Subject),
+		"sub":      authResp.Subject,
 		"username": authResp.PreferredUsername,
 	})
 
 	return &TokenInfo{
-		UserID: fmt.Sprintf("%d", authResp.Subject),
+		UserID: authResp.Subject,
 		Props: map[string]any{
 			"info":         string(userInfo),
 			"api_key":      true,

--- a/pkg/tokens/apikey.go
+++ b/pkg/tokens/apikey.go
@@ -40,15 +40,14 @@ func NewAPIKeyValidator(authURL string) *APIKeyValidator {
 
 // ValidateAPIKey validates an API key by calling the authentication webhook.
 // Returns TokenInfo on success, or an error if authentication/authorization fails.
-func (v *APIKeyValidator) ValidateAPIKey(ctx context.Context, apiKey, mcpServerID, mcpServerInstanceID string) (*TokenInfo, error) {
+func (v *APIKeyValidator) ValidateAPIKey(ctx context.Context, apiKey, mcpID string) (*TokenInfo, error) {
 	if v.authURL == "" {
 		return nil, fmt.Errorf("API key auth URL not configured")
 	}
 
 	// Build request body
 	reqBody := types.APIKeyAuthRequest{
-		MCPServerID:         mcpServerID,
-		MCPServerInstanceID: mcpServerInstanceID,
+		MCPID: mcpID,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/pkg/tokens/apikey.go
+++ b/pkg/tokens/apikey.go
@@ -1,0 +1,111 @@
+package tokens
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/obot-platform/mcp-oauth-proxy/pkg/types"
+)
+
+const (
+	// APIKeyPrefix is the prefix that identifies Obot API keys.
+	APIKeyPrefix = "ok1-"
+)
+
+// IsAPIKey checks if the token is an Obot API key (starts with "ok1-").
+func IsAPIKey(token string) bool {
+	return strings.HasPrefix(token, APIKeyPrefix)
+}
+
+// APIKeyValidator validates API keys by calling the authentication webhook.
+type APIKeyValidator struct {
+	authURL    string
+	httpClient *http.Client
+}
+
+// NewAPIKeyValidator creates a new API key validator.
+func NewAPIKeyValidator(authURL string) *APIKeyValidator {
+	return &APIKeyValidator{
+		authURL: authURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// ValidateAPIKey validates an API key by calling the authentication webhook.
+// Returns TokenInfo on success, or an error if authentication/authorization fails.
+func (v *APIKeyValidator) ValidateAPIKey(ctx context.Context, apiKey, mcpServerID, mcpServerInstanceID string) (*TokenInfo, error) {
+	if v.authURL == "" {
+		return nil, fmt.Errorf("API key auth URL not configured")
+	}
+
+	// Build request body
+	reqBody := types.APIKeyAuthRequest{
+		MCPServerID:         mcpServerID,
+		MCPServerInstanceID: mcpServerInstanceID,
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.authURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	// Make the request
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call auth webhook: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Parse response
+	var authResp types.APIKeyAuthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&authResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if !authResp.Authenticated {
+		errMsg := "authentication failed"
+		if authResp.Error != "" {
+			errMsg = authResp.Error
+		}
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+
+	if !authResp.Authorized {
+		errMsg := "authorization failed"
+		if authResp.Error != "" {
+			errMsg = authResp.Error
+		}
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+
+	// Build user info JSON for props
+	userInfo, _ := json.Marshal(map[string]any{
+		"sub":      fmt.Sprintf("%d", authResp.UserID),
+		"username": authResp.Username,
+	})
+
+	// Return token info
+	return &TokenInfo{
+		UserID: fmt.Sprintf("%d", authResp.UserID),
+		Props: map[string]any{
+			"info":         string(userInfo),
+			"api_key":      true,
+			"access_token": apiKey,
+		},
+	}, nil
+}

--- a/pkg/tokens/apikey.go
+++ b/pkg/tokens/apikey.go
@@ -68,7 +68,9 @@ func (v *APIKeyValidator) ValidateAPIKey(ctx context.Context, apiKey, mcpID stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to call auth webhook: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// Parse response
 	var authResp types.APIKeyAuthResponse

--- a/pkg/tokens/apikey_test.go
+++ b/pkg/tokens/apikey_test.go
@@ -1,0 +1,207 @@
+package tokens
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/obot-platform/mcp-oauth-proxy/pkg/types"
+)
+
+func TestIsAPIKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected bool
+	}{
+		{
+			name:     "valid API key prefix",
+			token:    "ok1-123-456-secret",
+			expected: true,
+		},
+		{
+			name:     "API key with just prefix",
+			token:    "ok1-",
+			expected: true,
+		},
+		{
+			name:     "JWT token",
+			token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+			expected: false,
+		},
+		{
+			name:     "simple token format",
+			token:    "user123:grant456:secret789",
+			expected: false,
+		},
+		{
+			name:     "empty token",
+			token:    "",
+			expected: false,
+		},
+		{
+			name:     "similar but different prefix",
+			token:    "ok2-123-456-secret",
+			expected: false,
+		},
+		{
+			name:     "prefix in middle of token",
+			token:    "someprefix-ok1-123",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsAPIKey(tt.token)
+			if result != tt.expected {
+				t.Errorf("IsAPIKey(%q) = %v, want %v", tt.token, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		apiKey         string
+		mcpServerID    string
+		mcpInstanceID  string
+		serverResponse *types.APIKeyAuthResponse
+		serverStatus   int
+		expectError    bool
+		expectedUserID string
+	}{
+		{
+			name:          "successful authentication and authorization",
+			apiKey:        "ok1-1-2-secret",
+			mcpServerID:   "server-123",
+			mcpInstanceID: "instance-456",
+			serverResponse: &types.APIKeyAuthResponse{
+				Authenticated: true,
+				Authorized:    true,
+				UserID:        42,
+				Username:      "testuser",
+			},
+			serverStatus:   http.StatusOK,
+			expectError:    false,
+			expectedUserID: "42",
+		},
+		{
+			name:          "authentication failed",
+			apiKey:        "ok1-invalid-key",
+			mcpServerID:   "server-123",
+			mcpInstanceID: "instance-456",
+			serverResponse: &types.APIKeyAuthResponse{
+				Authenticated: false,
+				Authorized:    false,
+				Error:         "invalid API key",
+			},
+			serverStatus: http.StatusOK,
+			expectError:  true,
+		},
+		{
+			name:          "authenticated but not authorized",
+			apiKey:        "ok1-1-2-secret",
+			mcpServerID:   "server-123",
+			mcpInstanceID: "instance-456",
+			serverResponse: &types.APIKeyAuthResponse{
+				Authenticated: true,
+				Authorized:    false,
+				Error:         "access denied to this MCP server",
+			},
+			serverStatus: http.StatusOK,
+			expectError:  true,
+		},
+		{
+			name:          "server error",
+			apiKey:        "ok1-1-2-secret",
+			mcpServerID:   "server-123",
+			mcpInstanceID: "instance-456",
+			serverResponse: &types.APIKeyAuthResponse{
+				Authenticated: false,
+				Authorized:    false,
+				Error:         "internal error",
+			},
+			serverStatus: http.StatusInternalServerError,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify the request
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST request, got %s", r.Method)
+				}
+
+				authHeader := r.Header.Get("Authorization")
+				expectedAuth := "Bearer " + tt.apiKey
+				if authHeader != expectedAuth {
+					t.Errorf("expected Authorization header %q, got %q", expectedAuth, authHeader)
+				}
+
+				// Verify request body
+				var reqBody types.APIKeyAuthRequest
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+				if reqBody.MCPServerID != tt.mcpServerID {
+					t.Errorf("expected MCPServerID %q, got %q", tt.mcpServerID, reqBody.MCPServerID)
+				}
+				if reqBody.MCPServerInstanceID != tt.mcpInstanceID {
+					t.Errorf("expected MCPServerInstanceID %q, got %q", tt.mcpInstanceID, reqBody.MCPServerInstanceID)
+				}
+
+				w.WriteHeader(tt.serverStatus)
+				if err := json.NewEncoder(w).Encode(tt.serverResponse); err != nil {
+					t.Errorf("failed to encode response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			// Create validator with test server URL
+			validator := NewAPIKeyValidator(server.URL)
+
+			// Validate the API key
+			tokenInfo, err := validator.ValidateAPIKey(context.Background(), tt.apiKey, tt.mcpServerID, tt.mcpInstanceID)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tokenInfo.UserID != tt.expectedUserID {
+				t.Errorf("expected UserID %q, got %q", tt.expectedUserID, tokenInfo.UserID)
+			}
+
+			// Verify props contain expected values
+			if tokenInfo.Props["api_key"] != true {
+				t.Errorf("expected api_key prop to be true")
+			}
+			if tokenInfo.Props["access_token"] != tt.apiKey {
+				t.Errorf("expected access_token prop to be %q, got %v", tt.apiKey, tokenInfo.Props["access_token"])
+			}
+		})
+	}
+}
+
+func TestAPIKeyValidator_EmptyAuthURL(t *testing.T) {
+	validator := NewAPIKeyValidator("")
+
+	_, err := validator.ValidateAPIKey(context.Background(), "ok1-test", "", "")
+	if err == nil {
+		t.Error("expected error for empty auth URL, got none")
+	}
+}

--- a/pkg/tokens/apikey_test.go
+++ b/pkg/tokens/apikey_test.go
@@ -67,18 +67,16 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 	tests := []struct {
 		name           string
 		apiKey         string
-		mcpServerID    string
-		mcpInstanceID  string
+		mcpID          string
 		serverResponse *types.APIKeyAuthResponse
 		serverStatus   int
 		expectError    bool
 		expectedUserID string
 	}{
 		{
-			name:          "successful authentication and authorization",
-			apiKey:        "ok1-1-2-secret",
-			mcpServerID:   "server-123",
-			mcpInstanceID: "instance-456",
+			name:   "successful authentication and authorization",
+			apiKey: "ok1-1-2-secret",
+			mcpID:  "server-123",
 			serverResponse: &types.APIKeyAuthResponse{
 				Authenticated: true,
 				Authorized:    true,
@@ -90,10 +88,9 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 			expectedUserID: "42",
 		},
 		{
-			name:          "authentication failed",
-			apiKey:        "ok1-invalid-key",
-			mcpServerID:   "server-123",
-			mcpInstanceID: "instance-456",
+			name:   "authentication failed",
+			apiKey: "ok1-invalid-key",
+			mcpID:  "server-123",
 			serverResponse: &types.APIKeyAuthResponse{
 				Authenticated: false,
 				Authorized:    false,
@@ -103,10 +100,9 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 			expectError:  true,
 		},
 		{
-			name:          "authenticated but not authorized",
-			apiKey:        "ok1-1-2-secret",
-			mcpServerID:   "server-123",
-			mcpInstanceID: "instance-456",
+			name:   "authenticated but not authorized",
+			apiKey: "ok1-1-2-secret",
+			mcpID:  "server-123",
 			serverResponse: &types.APIKeyAuthResponse{
 				Authenticated: true,
 				Authorized:    false,
@@ -116,10 +112,9 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 			expectError:  true,
 		},
 		{
-			name:          "server error",
-			apiKey:        "ok1-1-2-secret",
-			mcpServerID:   "server-123",
-			mcpInstanceID: "instance-456",
+			name:   "server error",
+			apiKey: "ok1-1-2-secret",
+			mcpID:  "server-123",
 			serverResponse: &types.APIKeyAuthResponse{
 				Authenticated: false,
 				Authorized:    false,
@@ -150,11 +145,8 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 					t.Errorf("failed to decode request body: %v", err)
 				}
-				if reqBody.MCPServerID != tt.mcpServerID {
-					t.Errorf("expected MCPServerID %q, got %q", tt.mcpServerID, reqBody.MCPServerID)
-				}
-				if reqBody.MCPServerInstanceID != tt.mcpInstanceID {
-					t.Errorf("expected MCPServerInstanceID %q, got %q", tt.mcpInstanceID, reqBody.MCPServerInstanceID)
+				if reqBody.MCPID != tt.mcpID {
+					t.Errorf("expected MCPID %q, got %q", tt.mcpID, reqBody.MCPID)
 				}
 
 				w.WriteHeader(tt.serverStatus)
@@ -168,7 +160,7 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 			validator := NewAPIKeyValidator(server.URL)
 
 			// Validate the API key
-			tokenInfo, err := validator.ValidateAPIKey(context.Background(), tt.apiKey, tt.mcpServerID, tt.mcpInstanceID)
+			tokenInfo, err := validator.ValidateAPIKey(context.Background(), tt.apiKey, tt.mcpID)
 
 			if tt.expectError {
 				if err == nil {
@@ -200,7 +192,7 @@ func TestAPIKeyValidator_ValidateAPIKey(t *testing.T) {
 func TestAPIKeyValidator_EmptyAuthURL(t *testing.T) {
 	validator := NewAPIKeyValidator("")
 
-	_, err := validator.ValidateAPIKey(context.Background(), "ok1-test", "", "")
+	_, err := validator.ValidateAPIKey(context.Background(), "ok1-test", "")
 	if err == nil {
 		t.Error("expected error for empty auth URL, got none")
 	}

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -158,7 +158,7 @@ func (tm *TokenManager) GetTokenInfoWithContext(ctx context.Context, tokenString
 		// If token format is not recognized, try API key validation
 		if errors.Is(err, ErrInvalidTokenFormat) {
 			if tm.apiKeyValidator == nil {
-				return nil, fmt.Errorf("API key authentication not configured")
+				return nil, err // Return the original error
 			}
 			return tm.apiKeyValidator.ValidateAPIKey(ctx, tokenString, mcpID)
 		}

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -142,18 +142,18 @@ func (tm *TokenManager) validateAccessToken(tokenString string) (*TokenInfo, err
 
 // GetTokenInfo extracts user information from a valid token
 func (tm *TokenManager) GetTokenInfo(tokenString string) (*TokenInfo, error) {
-	return tm.GetTokenInfoWithContext(context.Background(), tokenString, "", "")
+	return tm.GetTokenInfoWithContext(context.Background(), tokenString, "")
 }
 
 // GetTokenInfoWithContext extracts user information from a valid token with context support.
-// For API keys, mcpServerID and mcpServerInstanceID can be provided for scoped authorization.
-func (tm *TokenManager) GetTokenInfoWithContext(ctx context.Context, tokenString, mcpServerID, mcpServerInstanceID string) (*TokenInfo, error) {
+// For API keys, mcpID can be provided for scoped authorization.
+func (tm *TokenManager) GetTokenInfoWithContext(ctx context.Context, tokenString, mcpID string) (*TokenInfo, error) {
 	// Check if this is an API key first
 	if IsAPIKey(tokenString) {
 		if tm.apiKeyValidator == nil {
 			return nil, fmt.Errorf("API key authentication not configured")
 		}
-		return tm.apiKeyValidator.ValidateAPIKey(ctx, tokenString, mcpServerID, mcpServerInstanceID)
+		return tm.apiKeyValidator.ValidateAPIKey(ctx, tokenString, mcpID)
 	}
 
 	// Fall back to existing JWT/simple token validation

--- a/pkg/types/apikey_types.go
+++ b/pkg/types/apikey_types.go
@@ -1,0 +1,16 @@
+package types
+
+// APIKeyAuthRequest is the request body sent to the API key authentication webhook.
+type APIKeyAuthRequest struct {
+	MCPServerID         string `json:"mcpServerId,omitempty"`
+	MCPServerInstanceID string `json:"mcpServerInstanceId,omitempty"`
+}
+
+// APIKeyAuthResponse is the response from the API key authentication webhook.
+type APIKeyAuthResponse struct {
+	Authenticated bool   `json:"authenticated"`
+	Authorized    bool   `json:"authorized"`
+	UserID        uint   `json:"userId,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Error         string `json:"error,omitempty"`
+}

--- a/pkg/types/apikey_types.go
+++ b/pkg/types/apikey_types.go
@@ -2,8 +2,7 @@ package types
 
 // APIKeyAuthRequest is the request body sent to the API key authentication webhook.
 type APIKeyAuthRequest struct {
-	MCPServerID         string `json:"mcpServerId,omitempty"`
-	MCPServerInstanceID string `json:"mcpServerInstanceId,omitempty"`
+	MCPID string `json:"mcpId,omitempty"`
 }
 
 // APIKeyAuthResponse is the response from the API key authentication webhook.

--- a/pkg/types/apikey_types.go
+++ b/pkg/types/apikey_types.go
@@ -7,9 +7,11 @@ type APIKeyAuthRequest struct {
 
 // APIKeyAuthResponse is the response from the API key authentication webhook.
 type APIKeyAuthResponse struct {
-	Authenticated bool   `json:"authenticated"`
-	Authorized    bool   `json:"authorized"`
-	UserID        uint   `json:"userId,omitempty"`
-	Username      string `json:"username,omitempty"`
-	Error         string `json:"error,omitempty"`
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason,omitempty"`
+
+	Subject           string `json:"sub,omitempty"`
+	Name              string `json:"name,omitempty"`
+	PreferredUsername string `json:"preferred_username,omitempty"`
+	Email             string `json:"email,omitempty"`
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -11,20 +11,21 @@ const (
 
 // Config holds all configuration values for the OAuth proxy
 type Config struct {
-	Port              string
-	DatabaseDSN       string
-	OAuthClientID     string
-	OAuthClientSecret string
-	OAuthAuthorizeURL string
-	OAuthJWKSURL      string
-	ScopesSupported   string
-	EncryptionKey     string
-	MCPServerURL      string
-	Mode              string
-	RoutePrefix       string
-	CookieNamePrefix  string
-	MCPPaths          []string
-	APIKeyAuthURL     string // URL for API key authentication webhook
+	Port                 string
+	DatabaseDSN          string
+	OAuthClientID        string
+	OAuthClientSecret    string
+	OAuthAuthorizeURL    string
+	OAuthJWKSURL         string
+	ScopesSupported      string
+	EncryptionKey        string
+	MCPServerURL         string
+	Mode                 string
+	RoutePrefix          string
+	CookieNamePrefix     string
+	MCPPaths             []string
+	APIKeyAuthWebhookURL string
+	MCPServerID          string
 }
 
 // TokenData represents stored token data for OAuth 2.1 compliance

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -24,6 +24,7 @@ type Config struct {
 	RoutePrefix       string
 	CookieNamePrefix  string
 	MCPPaths          []string
+	APIKeyAuthURL     string // URL for API key authentication webhook
 }
 
 // TokenData represents stored token data for OAuth 2.1 compliance


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5360

This calls the new webhook route in Obot to validate that the API key is valid and provides access to the requested MCP server.