### PR TITLE
enhance: expose trusted issuer and audiences and harden external JWT validation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ type RootCmd struct {
 	OAuthClientID     string `name:"oauth-client-id" env:"OAUTH_CLIENT_ID" usage:"OAuth client ID from your OAuth provider" required:"true"`
 	OAuthClientSecret string `name:"oauth-client-secret" env:"OAUTH_CLIENT_SECRET" usage:"OAuth client secret from your OAuth provider" required:"true"`
 	OAuthAuthorizeURL string `name:"oauth-authorize-url" env:"OAUTH_AUTHORIZE_URL" usage:"Authorization endpoint URL from your OAuth provider (e.g., https://accounts.google.com)" required:"true"`
-	OAuthJWKSURL      string `name:"oauth-jwks-url" env:"OAUTH_JWKS_URL" usage:"JWKS endpoint URL from your OAuth provider (e.g., https://accounts.google.com/.well-known/openid-configuration/jwks)"`
+	OAuthJWKSURL      string `name:"oauth-jwks-url" env:"OAUTH_JWKS_URL" usage:"JWKS endpoint URL from your OAuth provider (e.g., https://accounts.google.com/.well-known/openid-configuration/jwks). Requires trusted-issuer to be set"`
 	TrustedIssuer     string `name:"trusted-issuer" env:"TRUSTED_ISSUER" usage:"Expected issuer (iss) claim for externally issued JWT access tokens (e.g., https://accounts.google.com). Required to accept externally issued JWTs"`
 	TrustedAudiences  string `name:"trusted-audiences" env:"TRUSTED_AUDIENCES" usage:"Comma-separated list of expected audience (aud) claims for externally issued JWT access tokens"`
 
@@ -123,6 +123,9 @@ func (c *RootCmd) validateConfig() error {
 	}
 	if c.MCPServerURL == "" {
 		return fmt.Errorf("mcp-server-url is required")
+	}
+	if c.OAuthJWKSURL != "" && c.TrustedIssuer == "" {
+		return fmt.Errorf("trusted-issuer is required when oauth-jwks-url is set: without it, JWT issuer and audience validation is silently skipped and any token signed by the trusted key is accepted")
 	}
 	if c.Mode == proxy.ModeProxy {
 		if u, err := url.Parse(c.MCPServerURL); err != nil || u.Scheme != "http" && u.Scheme != "https" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,8 @@ type RootCmd struct {
 	OAuthClientSecret string `name:"oauth-client-secret" env:"OAUTH_CLIENT_SECRET" usage:"OAuth client secret from your OAuth provider" required:"true"`
 	OAuthAuthorizeURL string `name:"oauth-authorize-url" env:"OAUTH_AUTHORIZE_URL" usage:"Authorization endpoint URL from your OAuth provider (e.g., https://accounts.google.com)" required:"true"`
 	OAuthJWKSURL      string `name:"oauth-jwks-url" env:"OAUTH_JWKS_URL" usage:"JWKS endpoint URL from your OAuth provider (e.g., https://accounts.google.com/.well-known/openid-configuration/jwks)"`
+	TrustedIssuer     string `name:"trusted-issuer" env:"TRUSTED_ISSUER" usage:"Expected issuer (iss) claim for externally issued JWT access tokens (e.g., https://accounts.google.com). Required to accept externally issued JWTs"`
+	TrustedAudiences  string `name:"trusted-audiences" env:"TRUSTED_AUDIENCES" usage:"Comma-separated list of expected audience (aud) claims for externally issued JWT access tokens"`
 
 	// Scopes and MCP configuration
 	ScopesSupported string `name:"scopes-supported" env:"SCOPES_SUPPORTED" usage:"Comma-separated list of supported OAuth scopes (e.g., 'openid,profile,email')" required:"true"`
@@ -68,6 +70,8 @@ func (c *RootCmd) Run(cobraCmd *cobra.Command, args []string) error {
 		OAuthClientSecret: c.OAuthClientSecret,
 		OAuthAuthorizeURL: c.OAuthAuthorizeURL,
 		OAuthJWKSURL:      c.OAuthJWKSURL,
+		TrustedIssuer:     c.TrustedIssuer,
+		TrustedAudiences:  proxy.ParseScopesSupported(c.TrustedAudiences),
 		ScopesSupported:   c.ScopesSupported,
 		MCPServerURL:      c.MCPServerURL,
 		EncryptionKey:     c.EncryptionKey,

--- a/pkg/tokens/manager.go
+++ b/pkg/tokens/manager.go
@@ -16,6 +16,16 @@ import (
 // ErrInvalidTokenFormat is returned when the token format is not recognized.
 var ErrInvalidTokenFormat = errors.New("invalid token format")
 
+// asymmetricSigningMethods restricts externally issued JWTs to asymmetric
+// algorithms. This prevents algorithm confusion attacks (e.g., HS256 using a
+// known public key as the HMAC secret) when validating tokens from a JWKS URL.
+var asymmetricSigningMethods = []string{
+	"RS256", "RS384", "RS512",
+	"ES256", "ES384", "ES512",
+	"PS256", "PS384", "PS512",
+	"EdDSA",
+}
+
 // TokenManager handles token generation and validation
 type TokenManager struct {
 	db               Database
@@ -76,7 +86,12 @@ func (tm *TokenManager) validateAccessToken(tokenString string) (*TokenInfo, err
 		}
 
 		// If this isn't a token for us, then we should check if it's a JWT token
-		token, err := jwt.Parse(tokenString, tm.keyFunc.Keyfunc, jwt.WithIssuer(tm.trustedIssuer), jwt.WithAudience(tm.trustedAudiences...))
+		token, err := jwt.Parse(tokenString, tm.keyFunc.Keyfunc,
+			jwt.WithValidMethods(asymmetricSigningMethods),
+			jwt.WithIssuer(tm.trustedIssuer),
+			jwt.WithAudience(tm.trustedAudiences...),
+			jwt.WithExpirationRequired(),
+		)
 		if err != nil {
 			return nil, ErrInvalidTokenFormat
 		}

--- a/pkg/tokens/manager_test.go
+++ b/pkg/tokens/manager_test.go
@@ -1,11 +1,19 @@
 package tokens
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/obot-platform/mcp-oauth-proxy/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -322,6 +330,128 @@ func TestTokenValidationEdgeCases(t *testing.T) {
 
 		_, err := tokenManager.validateAccessToken(validToken)
 		assert.NoError(t, err) // This should work with proper type
+	})
+}
+
+// jwksTestServer serves a JWKS document for the given RSA public key.
+func jwksTestServer(t *testing.T, key *rsa.PublicKey, kid string) *httptest.Server {
+	t.Helper()
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
+	n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+	jwks, err := json.Marshal(map[string]any{
+		"keys": []map[string]string{
+			{"kty": "RSA", "kid": kid, "alg": "RS256", "use": "sig", "n": n, "e": e},
+		},
+	})
+	require.NoError(t, err)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwks)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// signJWT creates a signed JWT with the given claims. alg must be "RS256"
+// (signed with key) or "HS256" (signed with the public key modulus bytes as
+// the HMAC secret, to assert algorithm confusion is rejected).
+func signJWT(t *testing.T, alg string, key *rsa.PrivateKey, claims map[string]any) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.GetSigningMethod(alg), jwt.MapClaims(claims))
+	token.Header["kid"] = "test-key"
+	secret := any(key)
+	if alg == "HS256" {
+		secret = key.PublicKey.N.Bytes()
+	}
+	signed, err := token.SignedString(secret)
+	require.NoError(t, err)
+	return signed
+}
+
+// TestExternalJWTValidation covers the externally issued JWT path (OAUTH_JWKS_URL):
+// signature/algorithm restrictions, required expiration, and issuer/audience checks.
+func TestExternalJWTValidation(t *testing.T) {
+	const (
+		issuer   = "https://idp.example.com"
+		audience = "mcp-proxy"
+	)
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	srv := jwksTestServer(t, &key.PublicKey, "test-key")
+
+	baseClaims := func() map[string]any {
+		return map[string]any{
+			"iss": issuer,
+			"aud": audience,
+			"sub": "user-from-jwt",
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}
+	}
+
+	t.Run("ValidToken", func(t *testing.T) {
+		tm, err := NewTokenManagerWithJWKSURL(NewMockDatabase(), srv.URL, issuer, []string{audience})
+		require.NoError(t, err)
+
+		info, err := tm.validateAccessToken(signJWT(t, "RS256", key, baseClaims()))
+		require.NoError(t, err)
+		assert.Equal(t, "user-from-jwt", info.UserID)
+	})
+
+	t.Run("HS256Rejected", func(t *testing.T) {
+		tm, err := NewTokenManagerWithJWKSURL(NewMockDatabase(), srv.URL, issuer, []string{audience})
+		require.NoError(t, err)
+
+		// HS256 signed with the known public key material must be rejected
+		// (algorithm confusion).
+		_, err = tm.validateAccessToken(signJWT(t, "HS256", key, baseClaims()))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token format")
+	})
+
+	t.Run("MissingExpRejected", func(t *testing.T) {
+		tm, err := NewTokenManagerWithJWKSURL(NewMockDatabase(), srv.URL, issuer, []string{audience})
+		require.NoError(t, err)
+
+		claims := baseClaims()
+		delete(claims, "exp")
+		_, err = tm.validateAccessToken(signJWT(t, "RS256", key, claims))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token format")
+	})
+
+	t.Run("IssuerMismatchRejected", func(t *testing.T) {
+		tm, err := NewTokenManagerWithJWKSURL(NewMockDatabase(), srv.URL, issuer, []string{audience})
+		require.NoError(t, err)
+
+		claims := baseClaims()
+		claims["iss"] = "https://evil.example.com"
+		_, err = tm.validateAccessToken(signJWT(t, "RS256", key, claims))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token format")
+	})
+
+	t.Run("AudienceMismatchRejected", func(t *testing.T) {
+		tm, err := NewTokenManagerWithJWKSURL(NewMockDatabase(), srv.URL, issuer, []string{audience})
+		require.NoError(t, err)
+
+		claims := baseClaims()
+		claims["aud"] = "someone-else"
+		_, err = tm.validateAccessToken(signJWT(t, "RS256", key, claims))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token format")
+	})
+
+	t.Run("ExpiredRejected", func(t *testing.T) {
+		tm, err := NewTokenManagerWithJWKSURL(NewMockDatabase(), srv.URL, issuer, []string{audience})
+		require.NoError(t, err)
+
+		claims := baseClaims()
+		claims["exp"] = time.Now().Add(-time.Hour).Unix()
+		_, err = tm.validateAccessToken(signJWT(t, "RS256", key, claims))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid token format")
 	})
 }
 


### PR DESCRIPTION
## Summary

#38 added `TrustedIssuer` and `TrustedAudiences` to the token manager, but they were never exposed as CLI flags or environment variables, and `golang-jwt/v5` silently disables issuer/audience checks when they are empty. As a result, a deployment configured with `OAUTH_JWKS_URL` accepts any token signed by the trusted JWKS key regardless of issuer, audience, or expiration.

This PR makes the external JWT trust policy configurable and fail-closed:

- add `--trusted-issuer` / `TRUSTED_ISSUER` and `--trusted-audiences` / `TRUSTED_AUDIENCES` (comma-separated), wiring them into the existing config fields
- restrict externally issued JWTs to asymmetric algorithms via `jwt.WithValidMethods`, preventing algorithm confusion (e.g. HS256 using the known public key as the HMAC secret)
- require `exp` via `jwt.WithExpirationRequired`, since tokens without it never expire
- fail fast at startup when `oauth-jwks-url` is set without `trusted-issuer`, instead of failing open

## Validation

- `TestExternalJWTValidation` with a JWKS test server covers the valid RS256 path and rejection of HS256 (algorithm confusion), missing `exp`, issuer mismatch, audience mismatch, and expired tokens
- `go test -short ./...` ✅
- `go vet ./...` ✅
- `gofmt -l` ✅
