### PR TITLE
enhance: add option to disable dynamic client registration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,8 @@ type RootCmd struct {
 	Version bool `name:"version" usage:"Show version information"`
 
 	Mode string `name:"mode" env:"MODE" usage:"Mode to run the server in" default:"proxy"`
+
+	DisableClientRegistration bool `name:"disable-client-registration" env:"DISABLE_CLIENT_REGISTRATION" usage:"Disable the RFC 7591 dynamic client registration endpoint (/register) and stop advertising it in the server metadata"`
 }
 
 func (c *RootCmd) Run(cobraCmd *cobra.Command, args []string) error {
@@ -63,16 +65,17 @@ func (c *RootCmd) Run(cobraCmd *cobra.Command, args []string) error {
 
 	// Convert CLI config to internal config format
 	config := &types.Config{
-		DatabaseDSN:       c.DatabaseDSN,
-		OAuthClientID:     c.OAuthClientID,
-		OAuthClientSecret: c.OAuthClientSecret,
-		OAuthAuthorizeURL: c.OAuthAuthorizeURL,
-		OAuthJWKSURL:      c.OAuthJWKSURL,
-		ScopesSupported:   c.ScopesSupported,
-		MCPServerURL:      c.MCPServerURL,
-		EncryptionKey:     c.EncryptionKey,
-		Mode:              c.Mode,
-		RoutePrefix:       c.RoutePrefix,
+		DatabaseDSN:               c.DatabaseDSN,
+		OAuthClientID:             c.OAuthClientID,
+		OAuthClientSecret:         c.OAuthClientSecret,
+		OAuthAuthorizeURL:         c.OAuthAuthorizeURL,
+		OAuthJWKSURL:              c.OAuthJWKSURL,
+		ScopesSupported:           c.ScopesSupported,
+		MCPServerURL:              c.MCPServerURL,
+		EncryptionKey:             c.EncryptionKey,
+		Mode:                      c.Mode,
+		RoutePrefix:               c.RoutePrefix,
+		DisableClientRegistration: c.DisableClientRegistration,
 	}
 
 	// Validate configuration

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -223,7 +223,9 @@ func (p *OAuthProxy) SetupRoutes(mux *http.ServeMux, next http.Handler) {
 	mux.HandleFunc("GET "+prefix+"/callback", p.withCORS(p.withRateLimit(callbackHandler)))
 	mux.HandleFunc("POST "+prefix+"/token", p.withCORS(p.withRateLimit(tokenHandler)))
 	mux.HandleFunc("POST "+prefix+"/revoke", p.withCORS(p.withRateLimit(revokeHandler)))
-	mux.HandleFunc("POST "+prefix+"/register", p.withCORS(p.withRateLimit(register.NewHandler(p.db))))
+	if !p.config.DisableClientRegistration {
+		mux.HandleFunc("POST "+prefix+"/register", p.withCORS(p.withRateLimit(register.NewHandler(p.db))))
+	}
 
 	// Metadata endpoints
 	mux.HandleFunc("GET /.well-known/oauth-authorization-server", p.withCORS(p.oauthMetadataHandler))
@@ -297,19 +299,22 @@ func (p *OAuthProxy) oauthMetadataHandler(w http.ResponseWriter, r *http.Request
 
 	// Create dynamic metadata based on the request
 	metadata := &types.OAuthMetadata{
-		Issuer:                                   baseURL,
-		ServiceDocumentation:                     p.metadata.ServiceDocumentation,
-		AuthorizationEndpoint:                    fmt.Sprintf("%s%s/authorize", baseURL, prefix),
-		ResponseTypesSupported:                   p.metadata.ResponseTypesSupported,
-		CodeChallengeMethodsSupported:            p.metadata.CodeChallengeMethodsSupported,
-		TokenEndpoint:                            fmt.Sprintf("%s%s/token", baseURL, prefix),
-		TokenEndpointAuthMethodsSupported:        p.metadata.TokenEndpointAuthMethodsSupported,
-		GrantTypesSupported:                      p.metadata.GrantTypesSupported,
-		ScopesSupported:                          p.metadata.ScopesSupported,
-		RevocationEndpoint:                       fmt.Sprintf("%s%s/revoke", baseURL, prefix),
-		RevocationEndpointAuthMethodsSupported:   p.metadata.RevocationEndpointAuthMethodsSupported,
-		RegistrationEndpoint:                     fmt.Sprintf("%s%s/register", baseURL, prefix),
-		RegistrationEndpointAuthMethodsSupported: p.metadata.RegistrationEndpointAuthMethodsSupported,
+		Issuer:                                 baseURL,
+		ServiceDocumentation:                   p.metadata.ServiceDocumentation,
+		AuthorizationEndpoint:                  fmt.Sprintf("%s%s/authorize", baseURL, prefix),
+		ResponseTypesSupported:                 p.metadata.ResponseTypesSupported,
+		CodeChallengeMethodsSupported:          p.metadata.CodeChallengeMethodsSupported,
+		TokenEndpoint:                          fmt.Sprintf("%s%s/token", baseURL, prefix),
+		TokenEndpointAuthMethodsSupported:      p.metadata.TokenEndpointAuthMethodsSupported,
+		GrantTypesSupported:                    p.metadata.GrantTypesSupported,
+		ScopesSupported:                        p.metadata.ScopesSupported,
+		RevocationEndpoint:                     fmt.Sprintf("%s%s/revoke", baseURL, prefix),
+		RevocationEndpointAuthMethodsSupported: p.metadata.RevocationEndpointAuthMethodsSupported,
+	}
+
+	if !p.config.DisableClientRegistration {
+		metadata.RegistrationEndpoint = fmt.Sprintf("%s%s/register", baseURL, prefix)
+		metadata.RegistrationEndpointAuthMethodsSupported = p.metadata.RegistrationEndpointAuthMethodsSupported
 	}
 
 	handlerutils.JSON(w, http.StatusOK, metadata)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -223,7 +223,16 @@ func (p *OAuthProxy) SetupRoutes(mux *http.ServeMux, next http.Handler) {
 	mux.HandleFunc("GET "+prefix+"/callback", p.withCORS(p.withRateLimit(callbackHandler)))
 	mux.HandleFunc("POST "+prefix+"/token", p.withCORS(p.withRateLimit(tokenHandler)))
 	mux.HandleFunc("POST "+prefix+"/revoke", p.withCORS(p.withRateLimit(revokeHandler)))
-	if !p.config.DisableClientRegistration {
+	if p.config.DisableClientRegistration {
+		// Serve an explicit 404 so clients get a deterministic error instead
+		// of /register falling through to the authenticated catch-all route.
+		mux.HandleFunc(prefix+"/register", p.withCORS(func(w http.ResponseWriter, r *http.Request) {
+			handlerutils.JSON(w, http.StatusNotFound, types.OAuthError{
+				Error:            "not_found",
+				ErrorDescription: "Client registration is disabled on this server",
+			})
+		}))
+	} else {
 		mux.HandleFunc("POST "+prefix+"/register", p.withCORS(p.withRateLimit(register.NewHandler(p.db))))
 	}
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/obot-platform/mcp-oauth-proxy/pkg/types"
@@ -499,6 +501,66 @@ func TestSpecialCharactersInHeaders(t *testing.T) {
 	assert.Equal(t, "test+tag@example.com", header.Get("X-Forwarded-Email"))
 	assert.Equal(t, "John O'Doe", header.Get("X-Forwarded-Name"))
 	assert.Equal(t, "token-with-special-chars_123", header.Get("X-Forwarded-Access-Token"))
+}
+
+// TestClientRegistrationDisabled tests that disabling client registration
+// removes the endpoint from the server metadata and makes /register
+// deterministically return 404.
+func TestClientRegistrationDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
+
+	newProxy := func(t *testing.T, disableRegistration bool) http.Handler {
+		t.Helper()
+		proxy, err := NewOAuthProxy(&types.Config{
+			Mode:                      ModeForwardAuth,
+			OAuthClientID:             "test_client_id",
+			OAuthClientSecret:         "test_client_secret",
+			OAuthAuthorizeURL:         "https://accounts.google.com",
+			ScopesSupported:           "openid,profile,email",
+			DisableClientRegistration: disableRegistration,
+		})
+		if err != nil {
+			t.Skipf("Skipping test due to database connection error: %v", err)
+		}
+		t.Cleanup(func() { _ = proxy.Close() })
+		return proxy.GetHandler()
+	}
+
+	getMetadata := func(t *testing.T, handler http.Handler) types.OAuthMetadata {
+		t.Helper()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, httptest.NewRequest("GET", "/.well-known/oauth-authorization-server", nil))
+		require.Equal(t, http.StatusOK, w.Code)
+		var metadata types.OAuthMetadata
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &metadata))
+		return metadata
+	}
+
+	t.Run("RegistrationEnabledByDefault", func(t *testing.T) {
+		handler := newProxy(t, false)
+
+		metadata := getMetadata(t, handler)
+		assert.NotEmpty(t, metadata.RegistrationEndpoint)
+
+		// Route is served by the register handler; an empty payload yields a
+		// 400 (invalid client metadata), proving the route is active.
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, httptest.NewRequest("POST", "/register", strings.NewReader("{}")))
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("RegistrationDisabled", func(t *testing.T) {
+		handler := newProxy(t, true)
+
+		metadata := getMetadata(t, handler)
+		assert.Empty(t, metadata.RegistrationEndpoint)
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, httptest.NewRequest("POST", "/register", strings.NewReader("{}")))
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
 }
 
 // BenchmarkSetHeaders benchmarks the header setting function

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -28,6 +28,10 @@ type Config struct {
 	MCPPaths             []string
 	APIKeyAuthWebhookURL string
 	MCPServerID          string
+	// DisableClientRegistration turns off the RFC 7591 dynamic client
+	// registration endpoint. When set, the /register endpoint is not served
+	// and no registration_endpoint is advertised in the server metadata.
+	DisableClientRegistration bool
 }
 
 // TokenData represents stored token data for OAuth 2.1 compliance


### PR DESCRIPTION
## Summary

The RFC 7591 dynamic client registration endpoint (`POST /register`) is always enabled and unauthenticated, with no way to turn it off. Deployments with a fixed, pre-registered set of clients have no option to prevent new clients from being created at runtime.

This PR adds `--disable-client-registration` / `DISABLE_CLIENT_REGISTRATION`:

- `/register` answers with a deterministic `404` (an explicit handler beats the authenticated catch-all route in `ServeMux` precedence, so clients get a clear error instead of a misleading `401`)
- `registration_endpoint` and `registration_endpoint_auth_methods_supported` are omitted from the advertised authorization server metadata, so spec-compliant clients will not attempt dynamic registration

## Validation

- `TestClientRegistrationDisabled` covers both states: default registration enabled (`400` on empty payload, `registration_endpoint` advertised) and disabled (`404`, no `registration_endpoint` in metadata)
- `go test -short ./...` ✅
- `go vet ./...` ✅
- `gofmt -l` ✅
